### PR TITLE
in_appscope: init commit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ option(FLB_PROXY_GO           "Enable Go plugins support"   Yes)
 option(FLB_CUSTOM_CALYPTIA    "Enable Calyptia Support"      Yes)
 
 # Built-in Plugins
+option(FLB_IN_APPSCOPE        "Enable AppScope input plugin"        Yes)
 option(FLB_IN_CPU             "Enable CPU input plugin"             Yes)
 option(FLB_IN_THERMAL         "Enable Thermal plugin"               Yes)
 option(FLB_IN_DISK            "Enable Disk input plugin"            Yes)
@@ -214,6 +215,7 @@ if(FLB_ALL)
   set(FLB_TLS          1)
 
   # Input plugins
+  set(FLB_IN_APPSCOPE  1)
   set(FLB_IN_CPU       1)
   set(FLB_IN_MEM       1)
   set(FLB_IN_KMSG      1)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Fluent Bit is fully supported on Windows environments, get started with [these i
 
 | name | title | description |
 | :--- | :--- | :--- |
+| [appscope](https://docs.fluentbit.io/manual/pipeline/inputs/appscope) | AppScope | Listen for event from AppScope. |
 | [collectd](https://docs.fluentbit.io/manual/pipeline/inputs/collectd) | Collectd | Listen for UDP packets from Collectd. |
 | [cpu](https://docs.fluentbit.io/manual/pipeline/inputs/cpu-metrics) | CPU Usage | measure total CPU usage of the system. |
 | [disk](https://docs.fluentbit.io/manual/pipeline/inputs/disk-io-metrics) | Disk Usage | measure Disk I/Os. |

--- a/cmake/windows-setup.cmake
+++ b/cmake/windows-setup.cmake
@@ -15,6 +15,7 @@ set(FLB_METRICS               Yes)
 
 # INPUT plugins
 # =============
+set(FLB_IN_APPSCOPE            No)
 set(FLB_IN_CPU                 No)
 set(FLB_IN_DISK                No)
 set(FLB_IN_EXEC                No)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -159,6 +159,7 @@ REGISTER_CUSTOM_PLUGIN("custom_calyptia")
 
 # These plugins works only on Linux
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  REGISTER_IN_PLUGIN("in_appscope")
   REGISTER_IN_PLUGIN("in_cpu")
   REGISTER_IN_PLUGIN("in_mem")
   REGISTER_IN_PLUGIN("in_thermal")

--- a/plugins/in_appscope/CMakeLists.txt
+++ b/plugins/in_appscope/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(src
+  appscope_conf.c
+  appscope_conn.c
+  appscope_prot.c
+  appscope_server.c
+  appscope.c)
+
+FLB_PLUGIN(in_appscope "${src}" "")

--- a/plugins/in_appscope/appscope.c
+++ b/plugins/in_appscope/appscope.c
@@ -1,0 +1,129 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <msgpack.h>
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_error.h>
+#include <fluent-bit/flb_utils.h>
+
+#include "appscope.h"
+#include "appscope_conf.h"
+#include "appscope_conn.h"
+#include "appscope_prot.h"
+#include "appscope_server.h"
+
+/* cb_collect callback */
+static int in_appscope_collect(struct flb_input_instance *i_ins,
+                                 struct flb_config *config, void *in_context)
+{
+    int fd;
+    struct flb_appscope *ctx = in_context;
+    struct appscope_conn *conn;
+    (void) i_ins;
+
+    /* Accept the new connection */
+    fd = flb_net_accept(ctx->server_fd);
+    if (fd == -1) {
+        flb_plg_error(ctx->ins, "could not accept new connection");
+        return -1;
+    }
+
+    flb_plg_debug(ctx->ins, "new Unix connection arrived FD=%i", fd);
+    conn = appscope_conn_add(fd, ctx);
+    if (!conn) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Initialize plugin */
+static int in_appscope_init(struct flb_input_instance *in,
+                          struct flb_config *config, void *data)
+{
+    int ret;
+    struct flb_appscope *ctx;
+
+    /* Allocate space for the configuration */
+    ctx = appscope_conf_create(in, config);
+    if (!ctx) {
+        flb_plg_error(in, "could not initialize plugin");
+        return -1;
+    }
+
+    if (!ctx->unix_path) {
+        flb_plg_error(ctx->ins, "Unix path not defined");
+        appscope_conf_destroy(ctx);
+        return -1;
+    }
+    ctx->unix_fs_socket = ctx->unix_path[0] != '@'; 
+
+    /* Create Unix Socket */
+    ret = appscope_server_create(ctx);
+    if (ret == -1) {
+        appscope_conf_destroy(ctx);
+        return -1;
+    }
+
+    /* Set context */
+    flb_input_set_context(in, ctx);
+
+    /* Collect events for every opened connection to our socket */
+    ret = flb_input_set_collector_socket(in,
+                                         in_appscope_collect,
+                                         ctx->server_fd,
+                                         config);
+
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "Could not set collector");
+        appscope_conf_destroy(ctx);
+    }
+
+    return 0;
+}
+
+static int in_appscope_exit(void *data, struct flb_config *config)
+{
+    struct flb_appscope *ctx = data;
+    (void) config;
+
+    appscope_conn_exit(ctx);
+    appscope_conf_destroy(ctx);
+
+    return 0;
+}
+
+struct flb_input_plugin in_appscope_plugin = {
+    .name         = "appscope",
+    .description  = "AppScope",
+    .cb_init      = in_appscope_init,
+    .cb_pre_run   = NULL,
+    .cb_collect   = NULL,
+    .cb_flush_buf = NULL,
+    .cb_exit      = in_appscope_exit,
+    .flags        = FLB_INPUT_NET
+};

--- a/plugins/in_appscope/appscope.h
+++ b/plugins/in_appscope/appscope.h
@@ -1,0 +1,53 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_APPSCOPE_H
+#define FLB_IN_APPSCOPE_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input.h>
+
+/* 32KB chunk size */
+#define FLB_APPSCOPE_CHUNK   32768
+#define FLB_APPSCOPE_IN_PARSER "_appscope_json"
+
+/* Context / Config */
+struct flb_appscope {
+    /* Unix socket TCP */
+    int server_fd;
+    char *unix_path;
+    unsigned int unix_perm;
+    bool unix_fs_socket;
+
+    /* Buffers setup */
+    size_t buffer_max_size;
+    size_t buffer_chunk_size;
+
+    /* Configuration */
+    struct flb_parser *parser;
+    bool is_parser_created;
+
+    /* List for connections and event loop */
+    struct mk_list connections;
+    struct mk_event_loop *evl;
+    struct flb_input_instance *ins;
+};
+
+#endif

--- a/plugins/in_appscope/appscope_conf.c
+++ b/plugins/in_appscope/appscope_conf.c
@@ -1,0 +1,101 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+#include <fluent-bit/flb_input.h>
+#include <fluent-bit/flb_str.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_utils.h>
+
+#include "appscope.h"
+#include "appscope_conf.h"
+#include "appscope_server.h"
+
+struct flb_appscope *appscope_conf_create(struct flb_input_instance *ins,
+                                      struct flb_config *config)
+{
+    const char *tmp;
+    struct flb_appscope *ctx;
+    struct flb_parser *parser;
+
+    ctx = flb_calloc(1, sizeof(struct flb_appscope));
+    if (!ctx) {
+        flb_errno();
+        return NULL;
+    }
+    ctx->evl = config->evl;
+    ctx->ins = ins;
+    mk_list_init(&ctx->connections);
+
+    tmp = flb_input_get_property("path", ins);
+    if (tmp) {
+        ctx->unix_path = flb_strdup(tmp);
+    }
+
+    tmp = flb_input_get_property("unix_perm", ins);
+    if (tmp) {
+        ctx->unix_perm = strtol(tmp, NULL, 8) & 07777;
+    } else {
+        ctx->unix_perm = 0644;
+    }
+
+    /* Buffer Chunk Size */
+    tmp = flb_input_get_property("buffer_chunk_size", ins);
+    if (!tmp) {
+        ctx->buffer_chunk_size = FLB_APPSCOPE_CHUNK; /* 32KB */
+    } else {
+        ctx->buffer_chunk_size = flb_utils_size_to_bytes(tmp);
+    }
+
+    /* Buffer Max Size */
+    tmp = flb_input_get_property("buffer_max_size", ins);
+    if (!tmp) {
+        ctx->buffer_max_size = ctx->buffer_chunk_size;
+    } else {
+        ctx->buffer_max_size = flb_utils_size_to_bytes(tmp);
+    }
+
+    /* Parser */
+    parser = flb_parser_get(FLB_APPSCOPE_IN_PARSER, config);
+    if (!parser) {
+        parser = flb_parser_create(FLB_APPSCOPE_IN_PARSER, "json", "%d/%b/%Y:%H:%M:%S %z",
+                                   NULL, NULL, NULL, MK_FALSE, 
+                                   MK_TRUE, NULL, 0, NULL, config);
+        ctx->is_parser_created = FLB_TRUE;
+    }
+
+    ctx->parser = parser;
+
+    return ctx;
+}
+
+int appscope_conf_destroy(struct flb_appscope *ctx)
+{
+    appscope_server_destroy(ctx);
+
+    if (ctx->is_parser_created && ctx->parser) {
+        flb_parser_destroy(ctx->parser);
+    }
+    flb_free(ctx);
+
+    return 0;
+}

--- a/plugins/in_appscope/appscope_conf.h
+++ b/plugins/in_appscope/appscope_conf.h
@@ -1,0 +1,33 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_APPSCOPE_CONF_H
+#define FLB_IN_APPSCOPE_CONF_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_input.h>
+
+#include "appscope.h"
+
+struct flb_appscope *appscope_conf_create(struct flb_input_instance *i_ins,
+                                      struct flb_config *config);
+int appscope_conf_destroy(struct flb_appscope *ctx);
+
+#endif

--- a/plugins/in_appscope/appscope_conn.c
+++ b/plugins/in_appscope/appscope_conn.c
@@ -1,0 +1,174 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_utils.h>
+#include <fluent-bit/flb_engine.h>
+#include <fluent-bit/flb_network.h>
+
+#include "appscope.h"
+#include "appscope_conf.h"
+#include "appscope_conn.h"
+#include "appscope_prot.h"
+
+static int appscope_conn_del(struct appscope_conn *conn)
+{
+    /* Unregister the file descriptior from the event-loop */
+    mk_event_del(conn->ctx->evl, &conn->event);
+
+    /* Release resources */
+    mk_list_del(&conn->_head);
+    close(conn->fd);
+    flb_free(conn->buf_data);
+    flb_free(conn);
+
+    return 0;
+}
+
+/* Callback invoked every time an event is triggered for a connection */
+int appscope_conn_event(void *data)
+{
+    int ret;
+    int bytes;
+    int available;
+    size_t size;
+    char *tmp;
+    struct mk_event *event;
+    struct appscope_conn *conn = data;
+    struct flb_appscope *ctx = conn->ctx;
+
+    event = &conn->event;
+    if (event->mask & MK_EVENT_READ) {
+        available = (conn->buf_size - conn->buf_len) - 1;
+        if (available < 1) {
+            if (conn->buf_size + ctx->buffer_chunk_size > ctx->buffer_max_size) {
+                flb_plg_debug(ctx->ins,
+                              "fd=%i incoming data exceed limit (%zd bytes)",
+                              event->fd, (ctx->buffer_max_size));
+                appscope_conn_del(conn);
+                return -1;
+            }
+
+            size = conn->buf_size + ctx->buffer_chunk_size;
+            tmp = flb_realloc(conn->buf_data, size);
+            if (!tmp) {
+                flb_errno();
+                return -1;
+            }
+            flb_plg_trace(ctx->ins, "fd=%i buffer realloc %zd -> %zd",
+                          event->fd, conn->buf_size, size);
+
+            conn->buf_data = tmp;
+            conn->buf_size = size;
+            available = (conn->buf_size - conn->buf_len) - 1;
+        }
+
+        bytes = read(conn->fd,
+                     conn->buf_data + conn->buf_len, available);
+        if (bytes > 0) {
+            flb_plg_trace(ctx->ins, "read()=%i pre_len=%zu now_len=%zu",
+                          bytes, conn->buf_len, conn->buf_len + bytes);
+            conn->buf_len += bytes;
+            conn->buf_data[conn->buf_len] = '\0';
+            ret = appscope_prot_process(conn);
+            if (ret == -1) {
+                return -1;
+            }
+            return bytes;
+        }
+        else {
+            flb_plg_trace(ctx->ins, "fd=%i closed connection", event->fd);
+            appscope_conn_del(conn);
+            return -1;
+        }
+    }
+
+    if (event->mask & MK_EVENT_CLOSE) {
+        flb_plg_trace(ctx->ins, "fd=%i hangup", event->fd);
+        appscope_conn_del(conn);
+        return -1;
+    }
+    return 0;
+}
+
+/* Create a new mqtt request instance */
+struct appscope_conn *appscope_conn_add(int fd, struct flb_appscope *ctx)
+{
+    int ret;
+    struct appscope_conn *conn;
+    struct mk_event *event;
+
+    conn = flb_malloc(sizeof(struct appscope_conn));
+    if (!conn) {
+        return NULL;
+    }
+
+    /* Set data for the event-loop */
+    event = &conn->event;
+    MK_EVENT_NEW(event);
+    event->fd           = fd;
+    event->type         = FLB_ENGINE_EV_CUSTOM;
+    event->handler      = appscope_conn_event;
+
+    /* Connection info */
+    conn->fd      = fd;
+    conn->ctx     = ctx;
+    conn->ins     = ctx->ins;
+    conn->buf_len = 0;
+    conn->buf_parsed = 0;
+
+    /* Allocate read buffer */
+    conn->buf_data = flb_malloc(ctx->buffer_chunk_size);
+    if (!conn->buf_data) {
+        flb_errno();
+        close(fd);
+        flb_free(conn);
+        return NULL;
+    }
+    conn->buf_size = ctx->buffer_chunk_size;
+
+    /* Register instance into the event loop */
+    ret = mk_event_add(ctx->evl, fd, FLB_ENGINE_EV_CUSTOM, MK_EVENT_READ, conn);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "could not register new connection");
+        close(fd);
+        flb_free(conn->buf_data);
+        flb_free(conn);
+        return NULL;
+    }
+
+    mk_list_add(&conn->_head, &ctx->connections);
+
+    return conn;
+}
+
+int appscope_conn_exit(struct flb_appscope *ctx)
+{
+    struct mk_list *tmp;
+    struct mk_list *head;
+    struct appscope_conn *conn;
+
+    mk_list_foreach_safe(head, tmp, &ctx->connections) {
+        conn = mk_list_entry(head, struct appscope_conn, _head);
+        appscope_conn_del(conn);
+    }
+
+    return 0;
+}

--- a/plugins/in_appscope/appscope_conn.h
+++ b/plugins/in_appscope/appscope_conn.h
@@ -1,0 +1,49 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_APPSCOPE_CONN_H
+#define FLB_IN_APPSCOPE_CONN_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+
+#include "appscope.h"
+
+/* Respresents a connection */
+struct appscope_conn {
+    struct mk_event event;           /* Built-in event data for mk_events */
+    int fd;                          /* Socket file descriptor            */
+    int status;                      /* Connection status                 */
+
+    /* Buffer */
+    char *buf_data;                  /* Buffer data                       */
+    size_t buf_size;                 /* Buffer size                       */
+    size_t buf_len;                  /* Buffer length                     */
+    size_t buf_parsed;               /* Parsed buffer (offset)            */
+    struct flb_input_instance *ins;  /* Parent plugin instance            */
+    struct flb_appscope *ctx;        /* Plugin configuration context      */
+
+    struct mk_list _head;
+};
+
+struct appscope_conn *appscope_conn_add(int fd, struct flb_appscope *ctx);
+int appscope_conn_exit(struct flb_appscope *ctx);
+
+#endif

--- a/plugins/in_appscope/appscope_prot.c
+++ b/plugins/in_appscope/appscope_prot.c
@@ -1,0 +1,128 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_input_plugin.h>
+#include <fluent-bit/flb_parser.h>
+#include <fluent-bit/flb_time.h>
+
+#include "appscope.h"
+#include "appscope_conn.h"
+
+#include <string.h>
+
+static inline void consume_bytes(char *buf, int bytes, int length)
+{
+    memmove(buf, buf + bytes, length - bytes);
+}
+
+static inline int pack_line(struct flb_appscope *ctx,
+                            struct flb_time *time, char *data, size_t data_size)
+{
+    msgpack_packer mp_pck;
+    msgpack_sbuffer mp_sbuf;
+
+    /* Initialize local msgpack buffer */
+    msgpack_sbuffer_init(&mp_sbuf);
+    msgpack_packer_init(&mp_pck, &mp_sbuf, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&mp_pck, 2);
+    flb_time_append_to_msgpack(time, &mp_pck, 0);
+    msgpack_sbuffer_write(&mp_sbuf, data, data_size);
+
+    flb_input_chunk_append_raw(ctx->ins, NULL, 0, mp_sbuf.data, mp_sbuf.size);
+    msgpack_sbuffer_destroy(&mp_sbuf);
+
+    return 0;
+}
+
+int appscope_prot_process(struct appscope_conn *conn)
+{
+    int len;
+    int ret;
+    char *p;
+    char *eof;
+    char *end;
+    void *out_buf;
+    size_t out_size;
+    struct flb_time out_time;
+    struct flb_appscope *ctx = conn->ctx;
+
+    eof = conn->buf_data;
+    end = conn->buf_data + conn->buf_len;
+
+    /* Always parse while some remaining bytes exists */
+    while (eof < end) {
+        /* Lookup the ending byte */
+        eof = p = conn->buf_data + conn->buf_parsed;
+        while (*eof != '\n' && *eof != '\0' && eof < end) {
+            eof++;
+        }
+
+        /* Incomplete message */
+        if (eof == end || (*eof != '\n' && *eof != '\0')) {
+            break;
+        }
+
+        /* No data ? */
+        len = (eof - p);
+        if (len == 0) {
+            consume_bytes(conn->buf_data, 1, conn->buf_len);
+            conn->buf_len--;
+            conn->buf_parsed = 0;
+            conn->buf_data[conn->buf_len] = '\0';
+            end = conn->buf_data + conn->buf_len;
+
+            if (conn->buf_len == 0) {
+                break;
+            }
+
+            continue;
+        }
+
+        /* Process the string */
+        ret = flb_parser_do(ctx->parser, p, len,
+                            &out_buf, &out_size, &out_time);
+        if (ret >= 0) {
+            if (flb_time_to_double(&out_time) == 0.0) {
+                flb_time_get(&out_time);
+            }
+            pack_line(ctx, &out_time, out_buf, out_size);
+            flb_free(out_buf);
+        }
+        else {
+            flb_plg_warn(ctx->ins, "error parsing log message with parser '%s'",
+                         ctx->parser->name);
+            flb_plg_debug(ctx->ins, "unparsed log message: %.*s", len, p);
+        }
+
+        conn->buf_parsed += len + 1;
+        end = conn->buf_data + conn->buf_len;
+        eof = conn->buf_data + conn->buf_parsed;
+    }
+
+    if (conn->buf_parsed > 0) {
+        consume_bytes(conn->buf_data, conn->buf_parsed, conn->buf_len);
+        conn->buf_len -= conn->buf_parsed;
+        conn->buf_parsed = 0;
+        conn->buf_data[conn->buf_len] = '\0';
+    }
+
+    return 0;
+}

--- a/plugins/in_appscope/appscope_prot.h
+++ b/plugins/in_appscope/appscope_prot.h
@@ -1,0 +1,30 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_APPSCOPE_PROT_H
+#define FLB_IN_APPSCOPE_PROT_H
+
+#include <fluent-bit/flb_info.h>
+
+#include "appscope.h"
+
+int appscope_prot_process(struct appscope_conn *conn);
+
+#endif

--- a/plugins/in_appscope/appscope_server.c
+++ b/plugins/in_appscope/appscope_server.c
@@ -1,0 +1,99 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_macros.h>
+#include <fluent-bit/flb_log.h>
+#include <fluent-bit/flb_socket.h>
+#include <fluent-bit/flb_network.h>
+
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "appscope.h"
+
+int appscope_server_create(struct flb_appscope *ctx)
+{
+    flb_sockfd_t fd = -1;
+    unsigned long len;
+    size_t address_length;
+    struct sockaddr_un address;
+    fd = flb_net_socket_create(AF_UNIX, ctx->unix_fs_socket);
+
+    if (fd == -1) {
+        return -1;
+    }
+
+    ctx->server_fd = fd;
+
+    /* Prepare the unix socket path */
+    len = strlen(ctx->unix_path);
+
+    memset(&address, 0, sizeof(address));
+    sprintf(address.sun_path, "%s", ctx->unix_path);
+    if (ctx->unix_fs_socket) {
+        unlink(ctx->unix_path);
+        address_length = sizeof(address);
+    }
+    else {
+        address.sun_path[0] = 0;
+        address_length = sizeof(address.sun_family) + len;
+    }
+    address.sun_family = AF_UNIX;
+
+    if (bind(fd, (struct sockaddr *) &address, address_length) != 0) {
+        flb_errno();
+        close(fd);
+        return -1;
+    }
+
+    if (ctx->unix_fs_socket && chmod(address.sun_path, ctx->unix_perm)) {
+        flb_errno();
+        flb_error("[in_appscope] cannot set permission on '%s' to %04o",
+                  address.sun_path, ctx->unix_perm);
+        close(fd);
+        return -1;
+    }
+
+    if (listen(fd, 5) != 0) {
+        flb_errno();
+        close(fd);
+        return -1;
+    }
+
+    return 0;
+}
+
+int appscope_server_destroy(struct flb_appscope *ctx)
+{
+    if (ctx->unix_path) {
+        if (ctx->unix_fs_socket) {
+            unlink(ctx->unix_path);
+        }
+        flb_free(ctx->unix_path);
+    }
+
+    close(ctx->server_fd);
+
+    return 0;
+}

--- a/plugins/in_appscope/appscope_server.h
+++ b/plugins/in_appscope/appscope_server.h
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  Fluent Bit
+ *  ==========
+ *  Copyright (C) 2019-2021 The Fluent Bit Authors
+ *  Copyright (C) 2015-2018 Treasure Data Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef FLB_IN_APPSCOPE_SERVER_H
+#define FLB_IN_APPSCOPE_SERVER_H
+
+#include <fluent-bit/flb_info.h>
+#include <fluent-bit/flb_config.h>
+
+#include "appscope.h"
+
+int appscope_server_create(struct flb_appscope *ctx);
+int appscope_server_destroy(struct flb_appscope *ctx);
+
+#endif


### PR DESCRIPTION
Signed-off-by: Michal Biesek <mbiesek@cribl.io>

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.

**TODO**
- [ ]  Add reference to Documentation: https://github.com/michalbiesek/fluent-bit-docs/tree/init-plugin-AppScope-docs
Ref: https://github.com/criblio/appscope/issues/541
        https://github.com/criblio/appscope/pull/553

## Config File
`test.conf`
Example Configuration:
```
[INPUT]
    Name appscope
    Path @abstract_socket
[OUTPUT]
    Name stdout
```



## Debug Log
After starting Fluent Bit instance call:
`LD_PRELOAD=lib/linux/x86_64/libscope.so SCOPE_EVENT_DEST=unix://@abstract_socket /bin/echo something`
```
./bin/fluent-bit -c test.conf 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/16 18:21:12] [ info] [engine] started (pid=2094303)
[2021/09/16 18:21:12] [ info] [storage] version=1.1.1, initializing...
[2021/09/16 18:21:12] [ info] [storage] in-memory
[2021/09/16 18:21:12] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/16 18:21:12] [ info] [cmetrics] version=0.2.1
[2021/09/16 18:21:12] [ info] [sp] stream processor started
[0] appscope.0: [1073766200.1193005953, {"format"=>"ndjson", "info"=>{"process"=>{"libscopever"=>"0.7.3-changelog-82-gea13f2ba0b89", "pid"=>2118012, "ppid"=>841301, "hostname"=>"x", "procname"=>"echo", "cmd"=>"/bin/echo something", "id"=>"x-echo-/bin/echo something"}, "configuration"=>{"current"=>{"metric"=>{"enable"=>"true", "transport"=>{"type"=>"udp", "host"=>"127.0.0.1", "port"=>"8125", "tls"=>{"enable"=>"false", "validateserver"=>"true", "cacertpath"=>""}}, "format"=>{"type"=>"statsd", "statsdprefix"=>"", "statsdmaxlen"=>512, "verbosity"=>4}}, "libscope"=>{"log"=>{"level"=>"warning", "transport"=>{"type"=>"file", "path"=>"/tmp/scope.log", "buffering"=>"line"}}, "configevent"=>"true", "summaryperiod"=>10, "commanddir"=>"/tmp"}, "event"=>{"enable"=>"true", "transport"=>{"type"=>"unix", "path"=>"@abstract_socket"}, "format"=>{"type"=>"ndjson", "maxeventpersec"=>10000, "enhancefs"=>"true"}, "watch"=>[{"type"=>"file", "name"=>"(\/logs?\/)|(\.log$)|(\.log[.\d])", "field"=>".*", "value"=>".*"}, {"type"=>"console", "name"=>"(stdout)|(stderr)", "field"=>".*", "value"=>".*"}, {"type"=>"http", "name"=>".*", "field"=>".*", "value"=>".*", "headers"=>[]}, {"type"=>"net", "name"=>".*", "field"=>".*", "value"=>".*"}, {"type"=>"fs", "name"=>".*", "field"=>".*", "value"=>".*"}, {"type"=>"dns", "name"=>".*", "field"=>".*", "value"=>".*"}]}, "payload"=>{"enable"=>"false", "dir"=>"/tmp"}, "tags"=>{}, "protocol"=>[]}}, "environment"=>{}}}]
[1] appscope.0: [1073766200.1193005953, {"type"=>"evt", "body"=>{"sourcetype"=>"console", "_time"=>1631809311.295564, "source"=>"stdout", "host"=>"x", "proc"=>"echo", "cmd"=>"/bin/echo something", "pid"=>2118012, "data"=>{"message"=>"something
"}}}]
^C[2021/09/16 18:21:56] [engine] caught signal (SIGINT)
[2021/09/16 18:21:56] [ warn] [engine] service will stop in 5 seconds
[2021/09/16 18:22:00] [ info] [engine] service stopped
```

## Valgrind
After starting Fluent Bit instance call:
`LD_PRELOAD=lib/linux/x86_64/libscope.so SCOPE_EVENT_DEST=unix://@abstract_socket /bin/echo something`
```
valgrind ./bin/fluent-bit -c test.conf 
==2197859== Memcheck, a memory error detector
==2197859== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==2197859== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==2197859== Command: ./bin/fluent-bit -c test.conf
==2197859== 
Fluent Bit v1.9.0
* Copyright (C) 2019-2021 The Fluent Bit Authors
* Copyright (C) 2015-2018 Treasure Data
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2021/09/16 18:23:54] [ info] [engine] started (pid=2197859)
[2021/09/16 18:23:54] [ info] [storage] version=1.1.1, initializing...
[2021/09/16 18:23:54] [ info] [storage] in-memory
[2021/09/16 18:23:54] [ info] [storage] normal synchronization mode, checksum disabled, max_chunks_up=128
[2021/09/16 18:23:54] [ info] [cmetrics] version=0.2.1
[2021/09/16 18:23:54] [ info] [sp] stream processor started
==2197859== Thread 2 flb-pipeline:
==2197859== Conditional jump or move depends on uninitialised value(s)
==2197859==    at 0x1B9BB8: appscope_prot_process (appscope_prot.c:103)
==2197859==    by 0x1B91DB: appscope_conn_event (appscope_conn.c:90)
==2197859==    by 0x18B254: flb_engine_start (flb_engine.c:735)
==2197859==    by 0x16C19D: flb_lib_worker (flb_lib.c:627)
==2197859==    by 0x486A608: start_thread (pthread_create.c:477)
==2197859==    by 0x4E81292: clone (clone.S:95)
==2197859== 
==2197859== Conditional jump or move depends on uninitialised value(s)
==2197859==    at 0x1B9BC2: appscope_prot_process (appscope_prot.c:103)
==2197859==    by 0x1B91DB: appscope_conn_event (appscope_conn.c:90)
==2197859==    by 0x18B254: flb_engine_start (flb_engine.c:735)
==2197859==    by 0x16C19D: flb_lib_worker (flb_lib.c:627)
==2197859==    by 0x486A608: start_thread (pthread_create.c:477)
==2197859==    by 0x4E81292: clone (clone.S:95)
==2197859== 
==2197859== Warning: client switching stacks?  SP change: 0x5b52888 --> 0x5009440
==2197859==          to suppress, use: --max-stackframe=11834440 or greater
==2197859== Warning: client switching stacks?  SP change: 0x50093b8 --> 0x5b52888
==2197859==          to suppress, use: --max-stackframe=11834576 or greater
==2197859== Warning: client switching stacks?  SP change: 0x5b52888 --> 0x50093b8
==2197859==          to suppress, use: --max-stackframe=11834576 or greater
==2197859==          further instances of this message will not be shown.
==2197859== Use of uninitialised value of size 8
==2197859==    at 0x4DBD81B: _itoa_word (_itoa.c:179)
==2197859==    by 0x4DD96F4: __vfprintf_internal (vfprintf-internal.c:1687)
==2197859==    by 0x4DC3EBE: printf (printf.c:33)
==2197859==    by 0x23AFC8: cb_stdout_flush (stdout.c:182)
==2197859==    by 0x179751: output_pre_cb_flush (flb_output.h:509)
==2197859==    by 0x4C7DEA: co_init (amd64.c:117)
==2197859== 
==2197859== Conditional jump or move depends on uninitialised value(s)
==2197859==    at 0x4DBD82D: _itoa_word (_itoa.c:179)
==2197859==    by 0x4DD96F4: __vfprintf_internal (vfprintf-internal.c:1687)
==2197859==    by 0x4DC3EBE: printf (printf.c:33)
==2197859==    by 0x23AFC8: cb_stdout_flush (stdout.c:182)
==2197859==    by 0x179751: output_pre_cb_flush (flb_output.h:509)
==2197859==    by 0x4C7DEA: co_init (amd64.c:117)
==2197859== 
==2197859== Conditional jump or move depends on uninitialised value(s)
==2197859==    at 0x4DDA3A8: __vfprintf_internal (vfprintf-internal.c:1687)
==2197859==    by 0x4DC3EBE: printf (printf.c:33)
==2197859==    by 0x23AFC8: cb_stdout_flush (stdout.c:182)
==2197859==    by 0x179751: output_pre_cb_flush (flb_output.h:509)
==2197859==    by 0x4C7DEA: co_init (amd64.c:117)
==2197859== 
==2197859== Conditional jump or move depends on uninitialised value(s)
==2197859==    at 0x4DD986E: __vfprintf_internal (vfprintf-internal.c:1687)
==2197859==    by 0x4DC3EBE: printf (printf.c:33)
==2197859==    by 0x23AFC8: cb_stdout_flush (stdout.c:182)
==2197859==    by 0x179751: output_pre_cb_flush (flb_output.h:509)
==2197859==    by 0x4C7DEA: co_init (amd64.c:117)
==2197859== 
[0] appscope.0: [83388472.075977601, {"format"=>"ndjson", "info"=>{"process"=>{"libscopever"=>"0.7.3-changelog-82-gea13f2ba0b89", "pid"=>2199281, "ppid"=>841301, "hostname"=>"x", "procname"=>"echo", "cmd"=>"/bin/echo something", "id"=>"x-echo-/bin/echo something"}, "configuration"=>{"current"=>{"metric"=>{"enable"=>"true", "transport"=>{"type"=>"udp", "host"=>"127.0.0.1", "port"=>"8125", "tls"=>{"enable"=>"false", "validateserver"=>"true", "cacertpath"=>""}}, "format"=>{"type"=>"statsd", "statsdprefix"=>"", "statsdmaxlen"=>512, "verbosity"=>4}}, "libscope"=>{"log"=>{"level"=>"warning", "transport"=>{"type"=>"file", "path"=>"/tmp/scope.log", "buffering"=>"line"}}, "configevent"=>"true", "summaryperiod"=>10, "commanddir"=>"/tmp"}, "event"=>{"enable"=>"true", "transport"=>{"type"=>"unix", "path"=>"@abstract_socket"}, "format"=>{"type"=>"ndjson", "maxeventpersec"=>10000, "enhancefs"=>"true"}, "watch"=>[{"type"=>"file", "name"=>"(\/logs?\/)|(\.log$)|(\.log[.\d])", "field"=>".*", "value"=>".*"}, {"type"=>"console", "name"=>"(stdout)|(stderr)", "field"=>".*", "value"=>".*"}, {"type"=>"http", "name"=>".*", "field"=>".*", "value"=>".*", "headers"=>[]}, {"type"=>"net", "name"=>".*", "field"=>".*", "value"=>".*"}, {"type"=>"fs", "name"=>".*", "field"=>".*", "value"=>".*"}, {"type"=>"dns", "name"=>".*", "field"=>".*", "value"=>".*"}]}, "payload"=>{"enable"=>"false", "dir"=>"/tmp"}, "tags"=>{}, "protocol"=>[]}}, "environment"=>{}}}]
[1] appscope.0: [83388472.075977601, {"type"=>"evt", "body"=>{"sourcetype"=>"console", "_time"=>1631809436.657405, "source"=>"stdout", "host"=>"x", "proc"=>"echo", "cmd"=>"/bin/echo something", "pid"=>2199281, "data"=>{"message"=>"something
"}}}]
^C[2021/09/16 18:24:06] [engine] caught signal (SIGINT)
[2021/09/16 18:24:06] [ warn] [engine] service will stop in 5 seconds
[2021/09/16 18:24:10] [ info] [engine] service stopped
==2197859== 
==2197859== HEAP SUMMARY:
==2197859==     in use at exit: 0 bytes in 0 blocks
==2197859==   total heap usage: 1,078 allocs, 1,078 frees, 962,531 bytes allocated
==2197859== 
==2197859== All heap blocks were freed -- no leaks are possible
==2197859== 
==2197859== Use --track-origins=yes to see where uninitialised values come from
==2197859== For lists of detected and suppressed errors, rerun with: -s
==2197859== ERROR SUMMARY: 76 errors from 6 contexts (suppressed: 0 from 0)
```
